### PR TITLE
Device page should notify user state change only after new device is …

### DIFF
--- a/app/src/main/java/org/mozilla/firefox/vpn/device/ui/DevicesViewModel.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/device/ui/DevicesViewModel.kt
@@ -94,14 +94,12 @@ class DevicesViewModel(
                 authorized = {
                     removeDeletingDevice(device)
                     registerBlocking()
+                    refreshDevices()
                 },
                 unauthorized = {
                     logoutUseCase()
                 }
             )
-            notifyUserStateUseCase()
-
-            refreshDevices()
         }
     }
 


### PR DESCRIPTION
…registered

If notify happens before the device is registered, the notify event will be observed by the MainActivity, which will then navigate and lock the screen to the setting page. So we should notify only after we're sure the new device is registered