### PR TITLE
[UI Polish] Prevent bottom sheet from collapsing once it has been scrolled

### DIFF
--- a/app/src/main/java/org/mozilla/firefox/vpn/servers/ui/ServersBottomSheetBehavior.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/servers/ui/ServersBottomSheetBehavior.kt
@@ -1,0 +1,59 @@
+package org.mozilla.firefox.vpn.servers.ui
+
+import android.view.View
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+
+class ServersBottomSheetBehavior<T : View> : BottomSheetBehavior<T>() {
+
+    private var isScrolled = false
+    private var isDown = false
+
+    override fun onNestedPreScroll(
+        coordinatorLayout: CoordinatorLayout,
+        child: T,
+        target: View,
+        dx: Int,
+        dy: Int,
+        consumed: IntArray,
+        type: Int
+    ) {
+        if (isDown && target.scrollY > 0) {
+            isScrolled = true
+        }
+
+        if (dy > 0 || !isScrolled) {
+            super.onNestedPreScroll(coordinatorLayout, child, target, dx, dy, consumed, type)
+        }
+    }
+
+    override fun onStopNestedScroll(
+        coordinatorLayout: CoordinatorLayout,
+        child: T,
+        target: View,
+        type: Int
+    ) {
+        isDown = false
+        super.onStopNestedScroll(coordinatorLayout, child, target, type)
+    }
+
+    override fun onStartNestedScroll(
+        coordinatorLayout: CoordinatorLayout,
+        child: T,
+        directTargetChild: View,
+        target: View,
+        axes: Int,
+        type: Int
+    ): Boolean {
+        isDown = true
+        isScrolled = false
+        return super.onStartNestedScroll(
+            coordinatorLayout,
+            child,
+            directTargetChild,
+            target,
+            axes,
+            type
+        )
+    }
+}

--- a/app/src/main/java/org/mozilla/firefox/vpn/servers/ui/ServersFragment.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/servers/ui/ServersFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Observer
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -44,12 +45,19 @@ class ServersFragment : BottomSheetDialogFragment() {
     override fun onStart() {
         super.onStart()
         dialog?.let {
-            val bottomSheet = it.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
-            bottomSheet?.layoutParams?.height = ViewGroup.LayoutParams.MATCH_PARENT
-            val behavior = BottomSheetBehavior.from(bottomSheet)
-            behavior.setBottomSheetCallback(bottomSheetBehaviorCallback)
-            behavior.peekHeight = 0
-            behavior.state = BottomSheetBehavior.STATE_EXPANDED
+            val bottomSheet = it.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet) ?: return@let
+            val params = (bottomSheet.layoutParams as? CoordinatorLayout.LayoutParams) ?: return@let
+            params.height = ViewGroup.LayoutParams.MATCH_PARENT
+
+            if (params.behavior !is ServersBottomSheetBehavior) {
+                params.behavior = ServersBottomSheetBehavior<FrameLayout>()
+            }
+
+            (params.behavior as? BottomSheetBehavior)?.apply {
+                setBottomSheetCallback(bottomSheetBehaviorCallback)
+                peekHeight = 0
+                state = BottomSheetBehavior.STATE_EXPANDED
+            }
         }
     }
 


### PR DESCRIPTION
Originally when the user scrolls to the top of the list, he can keep scrolling and the bottom sheet will start to collapse, this behavior makes the dialogue being easily be dismissed by accident. The costume behavior implemented in this PR only allows collapsing when it is already on the most top of the list, so the user has to lift his finger and drag again in order to collapse the bottom sheet