### PR TITLE
Check authorization state before connecting vpn

### DIFF
--- a/app/src/main/java/org/mozilla/firefox/vpn/main/vpn/VpnComponent.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/main/vpn/VpnComponent.kt
@@ -3,12 +3,15 @@ package org.mozilla.firefox.vpn.main.vpn
 import org.mozilla.firefox.vpn.CoreComponent
 import org.mozilla.firefox.vpn.GuardianComponent
 import org.mozilla.firefox.vpn.device.domain.CurrentDeviceUseCase
-import org.mozilla.firefox.vpn.main.vpn.domain.GetLatestUpdateMessage
+import org.mozilla.firefox.vpn.main.vpn.domain.GetLatestUpdateMessageUseCase
 import org.mozilla.firefox.vpn.main.vpn.domain.SetLatestUpdateMessageUseCase
 import org.mozilla.firefox.vpn.main.vpn.domain.VpnManagerStateProvider
 import org.mozilla.firefox.vpn.servers.domain.GetSelectedServerUseCase
 import org.mozilla.firefox.vpn.servers.domain.GetServersUseCase
 import org.mozilla.firefox.vpn.user.domain.GetVersionsUseCase
+import org.mozilla.firefox.vpn.user.domain.LogoutUseCase
+import org.mozilla.firefox.vpn.user.domain.NotifyUserStateUseCase
+import org.mozilla.firefox.vpn.user.domain.RefreshUserInfoUseCase
 
 interface VpnComponent {
     val viewModel: VpnViewModel
@@ -30,6 +33,9 @@ class VpnComponentImpl(
             currentDeviceUseCase = CurrentDeviceUseCase(deviceRepo, userRepo, userStateResolver),
             getVersionsUseCase = GetVersionsUseCase(userRepo),
             setLatestUpdateMessageUseCase = SetLatestUpdateMessageUseCase(prefs),
-            getLatestUpdateMessage = GetLatestUpdateMessage(prefs)
+            getLatestUpdateMessageUseCase = GetLatestUpdateMessageUseCase(prefs),
+            refreshUserInfoUseCase = RefreshUserInfoUseCase(userRepo),
+            logoutUseCase = LogoutUseCase(userRepo, deviceRepo),
+            notifyUserStateUseCase = NotifyUserStateUseCase(userStateResolver)
         )
 }

--- a/app/src/main/java/org/mozilla/firefox/vpn/main/vpn/domain/GetLatestUpdateMessageUseCase.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/main/vpn/domain/GetLatestUpdateMessageUseCase.kt
@@ -2,7 +2,7 @@ package org.mozilla.firefox.vpn.main.vpn.domain
 
 import android.content.SharedPreferences
 
-class GetLatestUpdateMessage(private val pref: SharedPreferences) {
+class GetLatestUpdateMessageUseCase(private val pref: SharedPreferences) {
 
     operator fun invoke(): Int {
         return pref.getInt(SetLatestUpdateMessageUseCase.PREF_LATEST_UPDATE_MESSAGE, 0)


### PR DESCRIPTION
New behavior: if the current device is being logged out from another one, it will navigate back to the onboarding page when the user turns on the VPN.