### PR TITLE
Check login state in onResume()

### DIFF
--- a/app/src/main/java/org/mozilla/firefox/vpn/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/onboarding/OnboardingActivity.kt
@@ -3,11 +3,13 @@ package org.mozilla.firefox.vpn.onboarding
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import kotlinx.android.synthetic.main.activity_onboarding.*
 import org.mozilla.firefox.vpn.R
+import org.mozilla.firefox.vpn.coreComponent
 import org.mozilla.firefox.vpn.guardianComponent
 import org.mozilla.firefox.vpn.main.MainActivity
 import org.mozilla.firefox.vpn.ui.GuardianSnackbar
@@ -20,13 +22,12 @@ import org.mozilla.firefox.vpn.util.viewModel
 class OnboardingActivity : AppCompatActivity() {
 
     private val component by lazy {
-        OnboardingComponentImpl(guardianComponent)
+        OnboardingComponentImpl(coreComponent, guardianComponent)
     }
 
     private val viewModel by viewModel { component.viewModel }
 
     private var shouldLaunchMainPage = false
-    private var isCustomTabLaunched = false
 
     private lateinit var customTab: LoginCustomTab
 
@@ -55,7 +56,6 @@ class OnboardingActivity : AppCompatActivity() {
         })
 
         viewModel.promptLogin.observe(this, Observer {
-            isCustomTabLaunched = true
             customTab.launchUrl(it)
         })
 
@@ -73,13 +73,19 @@ class OnboardingActivity : AppCompatActivity() {
                 addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             })
         })
+
+        viewModel.uiModel.observe(this, Observer {
+            loading_view.visibility = if (it.isLoading) {
+                View.VISIBLE
+            } else {
+                View.GONE
+            }
+        })
     }
 
     override fun onResume() {
-        if (isCustomTabLaunched) {
-            viewModel.cancelLoginFlow()
-        }
         super.onResume()
+        viewModel.resumeLoginFlow()
     }
 
     override fun onNewIntent(intent: Intent?) {

--- a/app/src/main/java/org/mozilla/firefox/vpn/onboarding/OnboardingComponent.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/onboarding/OnboardingComponent.kt
@@ -1,7 +1,11 @@
 package org.mozilla.firefox.vpn.onboarding
 
+import org.mozilla.firefox.vpn.CoreComponent
 import org.mozilla.firefox.vpn.GuardianComponent
 import org.mozilla.firefox.vpn.device.domain.AddDeviceUseCase
+import org.mozilla.firefox.vpn.onboarding.domain.ClearPendingLoginInfoUseCase
+import org.mozilla.firefox.vpn.onboarding.domain.GetPendingLoginInfoUseCase
+import org.mozilla.firefox.vpn.onboarding.domain.SetPendingLoginInfoUseCase
 import org.mozilla.firefox.vpn.user.domain.CreateUserUseCase
 import org.mozilla.firefox.vpn.user.domain.GetLoginInfoUseCase
 import org.mozilla.firefox.vpn.user.domain.VerifyLoginUseCase
@@ -11,14 +15,18 @@ interface OnboardingComponent {
 }
 
 class OnboardingComponentImpl(
+    private val coreComponent: CoreComponent,
     private val guardianComponent: GuardianComponent
-) : OnboardingComponent, GuardianComponent by guardianComponent {
+) : OnboardingComponent, GuardianComponent by guardianComponent, CoreComponent by coreComponent {
 
     override val viewModel: OnboardingViewModel
         get() = OnboardingViewModel(
             loginInfoUseCase = GetLoginInfoUseCase(userRepo),
             verifyLoginUseCase = VerifyLoginUseCase(userRepo),
             createUserUseCase = CreateUserUseCase(userRepo, userStateResolver),
-            addDeviceUseCase = AddDeviceUseCase(deviceRepo, userRepo)
+            addDeviceUseCase = AddDeviceUseCase(deviceRepo, userRepo),
+            setPendingLoginInfoUseCase = SetPendingLoginInfoUseCase(prefs),
+            getPendingLoginInfoUseCase = GetPendingLoginInfoUseCase(prefs),
+            clearPendingLoginInfoUseCase = ClearPendingLoginInfoUseCase(prefs)
         )
 }

--- a/app/src/main/java/org/mozilla/firefox/vpn/onboarding/domain/ClearPendingLoginInfoUseCase.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/onboarding/domain/ClearPendingLoginInfoUseCase.kt
@@ -1,0 +1,13 @@
+package org.mozilla.firefox.vpn.onboarding.domain
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+class ClearPendingLoginInfoUseCase(
+    private val prefs: SharedPreferences
+) {
+
+    operator fun invoke() {
+        prefs.edit { remove(SetPendingLoginInfoUseCase.PREF_PENDING_LOGIN_INFO) }
+    }
+}

--- a/app/src/main/java/org/mozilla/firefox/vpn/onboarding/domain/GetPendingLoginInfoUseCase.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/onboarding/domain/GetPendingLoginInfoUseCase.kt
@@ -1,0 +1,21 @@
+package org.mozilla.firefox.vpn.onboarding.domain
+
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import org.mozilla.firefox.vpn.service.LoginInfo
+
+class GetPendingLoginInfoUseCase(
+    private val prefs: SharedPreferences
+) {
+
+    operator fun invoke(): LoginInfo? {
+        return prefs.getString(SetPendingLoginInfoUseCase.PREF_PENDING_LOGIN_INFO, null)
+            ?.let {
+                try {
+                    Gson().fromJson(it, LoginInfo::class.java)
+                } catch (e: Exception) {
+                    null
+                }
+            }
+    }
+}

--- a/app/src/main/java/org/mozilla/firefox/vpn/onboarding/domain/SetPendingLoginInfoUseCase.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/onboarding/domain/SetPendingLoginInfoUseCase.kt
@@ -1,0 +1,19 @@
+package org.mozilla.firefox.vpn.onboarding.domain
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.google.gson.Gson
+import org.mozilla.firefox.vpn.service.LoginInfo
+
+class SetPendingLoginInfoUseCase(
+    private val prefs: SharedPreferences
+) {
+
+    operator fun invoke(info: LoginInfo) {
+        prefs.edit { putString(PREF_PENDING_LOGIN_INFO, Gson().toJson(info)) }
+    }
+
+    companion object {
+        const val PREF_PENDING_LOGIN_INFO = "pending_login_info"
+    }
+}

--- a/app/src/main/java/org/mozilla/firefox/vpn/user/domain/VerifyLoginUseCase.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/user/domain/VerifyLoginUseCase.kt
@@ -13,8 +13,11 @@ class VerifyLoginUseCase(
     private val userRepository: UserRepository
 ) {
 
-    suspend operator fun invoke(info: LoginInfo): Result<LoginResult> {
+    suspend operator fun invoke(info: LoginInfo, retry: Boolean): Result<LoginResult> {
         var result = userRepository.verifyLogin(info)
+        if (!retry) {
+            return result
+        }
 
         while (result is Result.Fail) {
             Log.d(TAG, "verify login fail, result=$result")

--- a/app/src/main/res/layout/activity_onboarding.xml
+++ b/app/src/main/res/layout/activity_onboarding.xml
@@ -18,4 +18,27 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/loading_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:visibility="gone"
+        android:focusable="true"
+        android:clickable="true">
+
+        <androidx.core.widget.ContentLoadingProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="?android:attr/progressBarStyle"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**Symptom**
After login in the custom tab, app is not redirected to the main activity, even if the user quit the custom tab manually, the page is still stuck at on-boarding page.

**Possible root cause**
OnboardingActivity is recycled by the system after the custom tab come to the foreground, thus OnboardingActivity is unable to monitor the verification progress.

**Solution**
Every time the app is resumed to the foreground, we check whether there's a pending log-in info, if yes, we will verify it and directly redirect to the MainActivity if verification is passed.