### PR TITLE
Remove spaces from UserAgent product name.

### DIFF
--- a/app/src/main/java/org/mozilla/firefox/vpn/service/GuardianService.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/service/GuardianService.kt
@@ -149,7 +149,7 @@ private class TimeoutInterceptor : Interceptor {
 private fun getUserAgent(): String {
     val os = "Android ${Build.VERSION.RELEASE}"
     val abi = Build.SUPPORTED_ABIS.firstOrNull()?.let { it } ?: "no-support-abi"
-    return "Firefox Private Network VPN/${BuildConfig.VERSION_NAME} ($os; $abi)"
+    return "FirefoxPrivateNetworkVPN/${BuildConfig.VERSION_NAME} ($os; $abi)"
 }
 
 data class LoginInfo(


### PR DESCRIPTION
We decided no spaces would make it easier to parse.

ios patch: https://github.com/mozilla-mobile/guardian-vpn-ios/commit/ddb54a20d1a4ee315158f668220aa2f0ec07fada
windows patch: https://github.com/mozilla-services/guardian-vpn-windows/pull/73