### PR TITLE
Fix initial selected server issue

### DIFF
--- a/app/src/main/java/org/mozilla/firefox/vpn/servers/domain/GetSelectedServerUseCase.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/servers/domain/GetSelectedServerUseCase.kt
@@ -8,29 +8,32 @@ class GetSelectedServerUseCase(
     private val serverRepository: ServerRepository
 ) {
 
-    operator fun invoke(servers: List<ServerInfo> = emptyList()): Result<ServerInfo> {
+    operator fun invoke(filterStrategy: FilterStrategy, servers: List<ServerInfo> = emptyList()): Result<ServerInfo> {
         val selected = serverRepository.getSelectedServer()
 
         return if (selected == null) {
-            defaultServerInfo(servers)
+            defaultServerInfo(filterStrategy, servers)
         } else {
-            findMatchedServerInfo(servers, selected.server)
+            findMatchedServerInfo(filterStrategy, servers, selected.server)
         }
     }
 
-    private fun findMatchedServerInfo(servers: List<ServerInfo>, selected: ServerInfo): Result<ServerInfo> {
+    private fun findMatchedServerInfo(filterStrategy: FilterStrategy, servers: List<ServerInfo>, selected: ServerInfo): Result<ServerInfo> {
         return if (servers.contains(selected)) {
             Result.Success(selected)
         } else {
-            defaultServerInfo(servers)
+            defaultServerInfo(filterStrategy, servers)
         }
     }
 
-    private fun defaultServerInfo(servers: List<ServerInfo>): Result<ServerInfo> {
+    private fun defaultServerInfo(filterStrategy: FilterStrategy, servers: List<ServerInfo>): Result<ServerInfo> {
         return if (servers.any { it.country.code == "us" }) {
-            Result.Success(servers.filter { it.country.code == "us" }.random())
+            val selected = servers.filter { it.country.code == "us" }.random()
+            serverRepository.setSelectedServer(filterStrategy, selected)
+            Result.Success(selected)
         } else {
             servers.firstOrNull()?.let {
+                serverRepository.setSelectedServer(filterStrategy, it)
                 Result.Success(it)
             } ?: Result.Fail(RuntimeException("No server available"))
         }

--- a/app/src/main/java/org/mozilla/firefox/vpn/servers/ui/ServersViewModel.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/servers/ui/ServersViewModel.kt
@@ -43,7 +43,7 @@ class ServersViewModel(
     }
 
     fun updateSelectedServer() {
-        getSelectedServerUseCase(servers.value ?: emptyList())
+        getSelectedServerUseCase(FilterStrategy.ByCity, servers.value ?: emptyList())
             .onSuccess { _selectedServer.value = it }
     }
 


### PR DESCRIPTION
root cause: 
If there is no selected server in prefs, we will create default selected server every time.

solution:
Once default selected server was created, then save it in the prefs.