### PR TITLE
[PGAND-285] Implement install attribution to help us understand where users are acquired from - Android

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,7 @@ dependencies {
     implementation project(':config')
     implementation(name:'country-flags', ext:'aar')
 
+    implementation 'com.android.installreferrer:installreferrer:1.1'
     implementation "net.sourceforge.streamsupport:android-retrofuture:$streamsupportVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
@@ -101,6 +102,7 @@ dependencies {
     ktlint 'com.pinterest:ktlint:0.35.0'
 
     testImplementation 'junit:junit:4.12'
+    testImplementation "org.robolectric:robolectric:3.4.2"
     testImplementation 'androidx.arch.core:core-testing:2.1.0'
     testImplementation 'com.google.truth:truth:1.0.1'
     testImplementation 'io.mockk:mockk:1.9'

--- a/app/src/main/java/org/mozilla/firefox/vpn/GuardianComponent.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/GuardianComponent.kt
@@ -10,6 +10,7 @@ import org.mozilla.firefox.vpn.servers.domain.SelectedServerProvider
 import org.mozilla.firefox.vpn.service.GuardianService
 import org.mozilla.firefox.vpn.service.newInstance
 import org.mozilla.firefox.vpn.update.UpdateManager
+import org.mozilla.firefox.vpn.user.data.ReferralManager
 import org.mozilla.firefox.vpn.user.data.SessionManager
 import org.mozilla.firefox.vpn.user.data.UserRepository
 
@@ -30,10 +31,12 @@ class GuardianComponentImpl(
 
     private val sessionManager = SessionManager(prefs)
 
+    private val referralManager = ReferralManager(coreComponent.app.applicationContext, prefs)
+
     var service = GuardianService.newInstance(sessionManager)
 
     override val userRepo: UserRepository by lazy {
-        UserRepository(service, sessionManager)
+        UserRepository(service, sessionManager, referralManager)
     }
 
     override val deviceRepo: DeviceRepository by lazy {

--- a/app/src/main/java/org/mozilla/firefox/vpn/MockedGuardianComponent.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/MockedGuardianComponent.kt
@@ -9,6 +9,7 @@ import org.mozilla.firefox.vpn.servers.data.ServerRepository
 import org.mozilla.firefox.vpn.servers.domain.SelectedServerProvider
 import org.mozilla.firefox.vpn.service.MockGuardianService
 import org.mozilla.firefox.vpn.update.UpdateManager
+import org.mozilla.firefox.vpn.user.data.ReferralManager
 import org.mozilla.firefox.vpn.user.data.SessionManager
 import org.mozilla.firefox.vpn.user.data.UserRepository
 
@@ -18,10 +19,12 @@ class MockedGuardianComponent(
 
     private val sessionManager = SessionManager(prefs)
 
+    private val referralManager = ReferralManager(coreComponent.app.applicationContext, prefs)
+
     var service = MockGuardianService()
 
     override val userRepo: UserRepository by lazy {
-        UserRepository(service, sessionManager)
+        UserRepository(service, sessionManager, referralManager)
     }
 
     override val deviceRepo: DeviceRepository by lazy {

--- a/app/src/main/java/org/mozilla/firefox/vpn/service/GuardianService.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/service/GuardianService.kt
@@ -1,6 +1,8 @@
 package org.mozilla.firefox.vpn.service
 
+import android.net.Uri
 import android.os.Build
+import androidx.core.net.toUri
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonDeserializationContext
@@ -30,11 +32,12 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.QueryMap
 import retrofit2.http.Url
 
 interface GuardianService {
     @POST("api/v1/vpn/login")
-    suspend fun getLoginInfo(): Response<LoginInfo>
+    suspend fun getLoginInfo(@QueryMap referral: Map<String, String>): Response<LoginInfo>
 
     @GET
     suspend fun verifyLogin(@Url verifyUrl: String): Response<LoginResult>
@@ -321,6 +324,18 @@ data class Version(
     @SerializedName("message")
     val message: String
 )
+
+class LoginQueryBuilder(private val referral: String) {
+
+    fun build(): Map<String, String> {
+        return "mozilla.com?$referral".toUri().let { uri ->
+            uri.queryParameterNames
+                .filter { it.isNotEmpty() } // parameter name shouldn't be empty
+                .map { it to (uri.getQueryParameter(it) ?: "") }
+                .toMap()
+        }
+    }
+}
 
 data class DeviceRequestBody(
     val name: String,

--- a/app/src/main/java/org/mozilla/firefox/vpn/service/MockGuardianService.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/service/MockGuardianService.kt
@@ -59,7 +59,7 @@ class MockGuardianService : GuardianService {
 
     private val countries = listOf(Country("Mock country", "US", cities))
 
-    override suspend fun getLoginInfo(): Response<LoginInfo> {
+    override suspend fun getLoginInfo(loginRequestBody: Map<String, String>): Response<LoginInfo> {
         delay()
         return Response.success(LoginInfo(
             loginUrl,

--- a/app/src/main/java/org/mozilla/firefox/vpn/user/data/ReferralManager.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/user/data/ReferralManager.kt
@@ -6,6 +6,7 @@ import com.android.installreferrer.api.InstallReferrerClient
 import com.android.installreferrer.api.InstallReferrerStateListener
 import com.android.installreferrer.api.ReferrerDetails
 import kotlinx.coroutines.suspendCancellableCoroutine
+import org.mozilla.firefox.vpn.util.BuildConfigExt
 import org.mozilla.firefox.vpn.util.GLog
 import kotlin.coroutines.resume
 
@@ -22,10 +23,12 @@ class ReferralManager(context: Context, private val prefs: SharedPreferences) {
 
 
     suspend fun getUserReferral() = suspendCancellableCoroutine<String> { cont ->
-        GLog.d(TAG, "skip referral info in production-build")
-        if (cont.isActive) {
-            cont.resume("")
-            return@suspendCancellableCoroutine
+        if (!BuildConfigExt.isFlavorPreview() && !BuildConfigExt.isBuildTypeDebug()) {
+            GLog.d(TAG, "skip referral info in production-build")
+            if (cont.isActive) {
+                cont.resume("")
+                return@suspendCancellableCoroutine
+            }
         }
         val cacheReferral = prefs.getString(SIR_PREF_REFERRAL, null)
         if (cacheReferral != null) {

--- a/app/src/main/java/org/mozilla/firefox/vpn/user/data/ReferralManager.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/user/data/ReferralManager.kt
@@ -1,0 +1,78 @@
+package org.mozilla.firefox.vpn.user.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.android.installreferrer.api.InstallReferrerClient
+import com.android.installreferrer.api.InstallReferrerStateListener
+import com.android.installreferrer.api.ReferrerDetails
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.mozilla.firefox.vpn.util.GLog
+import kotlin.coroutines.resume
+
+class ReferralManager(context: Context, private val prefs: SharedPreferences) {
+
+    companion object {
+        private const val TAG = "ReferralManager"
+        private const val SIR_PREF_REFERRAL = "sir_pref_referral"
+        private const val DEFAULT_REFERRAL = ""
+    }
+
+    private var referrerClient: InstallReferrerClient =
+        InstallReferrerClient.newBuilder(context).build()
+
+
+    suspend fun getUserReferral() = suspendCancellableCoroutine<String> { cont ->
+        GLog.d(TAG, "skip referral info in production-build")
+        if (cont.isActive) {
+            cont.resume("")
+            return@suspendCancellableCoroutine
+        }
+        val cacheReferral = prefs.getString(SIR_PREF_REFERRAL, null)
+        if (cacheReferral != null) {
+            GLog.d(TAG, "referral already submitted")
+            if (cont.isActive) {
+                cont.resume(cacheReferral)
+                return@suspendCancellableCoroutine
+            }
+        }
+        referrerClient.startConnection(object : InstallReferrerStateListener {
+
+            override fun onInstallReferrerSetupFinished(responseCode: Int) {
+                when (responseCode) {
+                    InstallReferrerClient.InstallReferrerResponse.OK -> {
+                        val response: ReferrerDetails = referrerClient.installReferrer
+                        val referrerUrl: String = response.installReferrer
+                        prefs.edit().putString(SIR_PREF_REFERRAL, referrerUrl).apply()
+                        if (cont.isActive) {
+                            GLog.d(TAG, "onInstallReferrerSetupFinished")
+                            cont.resume(referrerUrl)
+                            return
+                        }
+                    }
+                    InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED -> {
+                        // API not available on the current Play Store app or there's no Play Store
+                        GLog.w(TAG, "FEATURE_NOT_SUPPORTED")
+                    }
+                    InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE -> {
+                        // Connection couldn't be established.
+                        GLog.w(TAG, "SERVICE_UNAVAILABLE")
+                    }
+                }
+                if (cont.isActive) {
+                    cont.resume(DEFAULT_REFERRAL)
+                    return
+                }
+            }
+
+            override fun onInstallReferrerServiceDisconnected() {
+                // Try to restart the connection on the next request to
+                // Google Play by calling the startConnection() method.
+                if (cont.isActive) {
+                    GLog.w(TAG, "onInstallReferrerServiceDisconnected")
+                    cont.resume(DEFAULT_REFERRAL)
+                    return
+                }
+            }
+        })
+    }
+}

--- a/app/src/main/java/org/mozilla/firefox/vpn/user/data/UserRepository.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/user/data/UserRepository.kt
@@ -3,6 +3,7 @@ package org.mozilla.firefox.vpn.user.data
 import java.net.UnknownHostException
 import org.mozilla.firefox.vpn.service.GuardianService
 import org.mozilla.firefox.vpn.service.LoginInfo
+import org.mozilla.firefox.vpn.service.LoginQueryBuilder
 import org.mozilla.firefox.vpn.service.LoginResult
 import org.mozilla.firefox.vpn.service.NetworkException
 import org.mozilla.firefox.vpn.service.Subscription
@@ -27,7 +28,8 @@ import org.mozilla.firefox.vpn.util.onSuccess
 
 class UserRepository(
     private val guardianService: GuardianService,
-    private val sessionManager: SessionManager
+    private val sessionManager: SessionManager,
+    private val referralManager: ReferralManager
 ) {
 
     /**
@@ -35,7 +37,8 @@ class UserRepository(
      */
     suspend fun getLoginInfo(): Result<LoginInfo> {
         return try {
-            guardianService.getLoginInfo().resolveBody()
+            val loginQueryBuilder = LoginQueryBuilder(referralManager.getUserReferral())
+            guardianService.getLoginInfo(loginQueryBuilder.build()).resolveBody()
         } catch (e: UnknownHostException) {
             Result.Fail(NetworkException)
         } catch (e: Exception) {

--- a/app/src/main/java/org/mozilla/firefox/vpn/util/BuildConfigExt.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/util/BuildConfigExt.kt
@@ -1,0 +1,12 @@
+package org.mozilla.firefox.vpn.util
+
+import org.mozilla.firefox.vpn.BuildConfig
+
+object BuildConfigExt {
+    private const val BUILD_FLAVOR_PREVIEW = "preview"
+    private const val BUILD_TYPE_DEBUG = "debug"
+
+    fun isFlavorPreview() = BuildConfig.FLAVOR == BUILD_FLAVOR_PREVIEW
+
+    fun isBuildTypeDebug() = BuildConfig.BUILD_TYPE == BUILD_TYPE_DEBUG
+}

--- a/app/src/test/java/org/mozilla/firefox/vpn/service/LoginQueryBuilderTest.kt
+++ b/app/src/test/java/org/mozilla/firefox/vpn/service/LoginQueryBuilderTest.kt
@@ -1,0 +1,39 @@
+package org.mozilla.firefox.vpn.service
+
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LoginQueryBuilderTest {
+
+    @Test
+    fun `only send valid referral info to backend`() {
+        var loginQueryBuilder = LoginQueryBuilder("")
+        assertTrue(loginQueryBuilder.build().isEmpty())
+
+        loginQueryBuilder = LoginQueryBuilder("aaa")
+        assertTrue(loginQueryBuilder.build().size == 1)
+
+        loginQueryBuilder = LoginQueryBuilder("aaa=")
+        assertTrue(loginQueryBuilder.build().size == 1)
+
+        loginQueryBuilder = LoginQueryBuilder("=aaa")
+        assertTrue(loginQueryBuilder.build().isEmpty())
+
+        loginQueryBuilder = LoginQueryBuilder("aaa=xxx")
+        assertTrue(loginQueryBuilder.build().size == 1)
+
+        loginQueryBuilder = LoginQueryBuilder("?aaa")
+        assertTrue(loginQueryBuilder.build().size == 1)
+
+        loginQueryBuilder = LoginQueryBuilder("aaa=xxx&bbb=zzz")
+        assertTrue(loginQueryBuilder.build().size == 2)
+
+        loginQueryBuilder = LoginQueryBuilder("aaa=xxx&=zzz")
+        assertTrue(loginQueryBuilder.build().size == 1)
+
+    }
+}


### PR DESCRIPTION
see: https://jira.mozilla.com/browse/PGAND-285

Once the referral info is fetched from Play Store, it'll be cached.
Whenever the user sends a POST/ login request, the info will be appended to the URL and send to the server.
