### PR TITLE
Split Tunneling UI improvement

### DIFF
--- a/app/src/main/java/org/mozilla/firefox/vpn/apptunneling/ui/AppGroupViewHolder.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/apptunneling/ui/AppGroupViewHolder.kt
@@ -64,11 +64,9 @@ class AppGroupViewHolder(
         }
 
         if (appGroupItem.isEnabled) {
-            binding.root.setOnClickListener { onAppGroupClicked(this) }
             binding.groupAction.setOnClickListener { onAppGroupActionClicked(this) }
             binding.groupAction.alpha = 1f
         } else {
-            binding.root.setOnClickListener(null)
             binding.groupAction.setOnClickListener(null)
             binding.groupAction.alpha = 0.5f
         }

--- a/app/src/main/java/org/mozilla/firefox/vpn/apptunneling/ui/ExpandableAdapter.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/apptunneling/ui/ExpandableAdapter.kt
@@ -154,7 +154,7 @@ class ExpandableAdapter(
                 val newItem = newList[newItemPosition]
                 val oldItem = oldList[oldItemPosition]
                 if (newItem is AppGroup && oldItem is AppGroup) {
-                    return newItem.appItems.size == oldItem.appItems.size &&
+                    return newItem.appItems == oldItem.appItems &&
                             newItem.isExpanded == oldItem.isExpanded &&
                             newItem.isEnabled == oldItem.isEnabled
                 }

--- a/app/src/main/res/layout/fragment_app_tunneling.xml
+++ b/app/src/main/res/layout/fragment_app_tunneling.xml
@@ -26,6 +26,7 @@
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
         android:elevation="4dp"
+        app:cardCornerRadius="8dp"
         app:layout_constraintTop_toBottomOf="@id/toolbar"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">

--- a/app/src/main/res/layout/fragment_app_tunneling.xml
+++ b/app/src/main/res/layout/fragment_app_tunneling.xml
@@ -18,6 +18,15 @@
         app:titleTextAppearance="@style/TextAppearance.Guardian.Header20"
         app:navigationIcon="@drawable/ic_back" />
 
+    <ImageView
+        android:id="@+id/header_line"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:background="@color/gray10"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
     <androidx.cardview.widget.CardView
         android:id="@+id/app_tunneling_switch"
         android:layout_width="0dp"
@@ -27,7 +36,7 @@
         android:layout_marginEnd="16dp"
         android:elevation="4dp"
         app:cardCornerRadius="8dp"
-        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintTop_toBottomOf="@id/header_line"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 

--- a/app/src/main/res/layout/item_app.xml
+++ b/app/src/main/res/layout/item_app.xml
@@ -21,21 +21,24 @@
 
     <TextView
         android:id="@+id/app_name"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
         android:textColor="@color/gray50"
         android:textAppearance="@style/TextAppearance.Guardian.Body10"
+        android:singleLine="true"
+        android:ellipsize="end"
         app:layout_constraintTop_toTopOf="@id/app_icon"
         app:layout_constraintBottom_toBottomOf="@id/app_icon"
         app:layout_constraintStart_toEndOf="@id/app_icon"
+        app:layout_constraintEnd_toStartOf="@id/app_checkbox"
         tools:text="Mozilla VPN"/>
 
     <TextView
         android:id="@+id/app_package_name"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
         android:textColor="@color/gray40"
         android:textAppearance="@style/TextAppearance.Guardian.Byline10"
         android:singleLine="true"
@@ -43,7 +46,7 @@
         app:layout_constraintTop_toBottomOf="@id/app_name"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="@id/app_name"
-        app:layout_constraintEnd_toStartOf="@id/app_checkbox"
+        app:layout_constraintEnd_toEndOf="@id/app_name"
         tools:text="org.mozilla.firefox.vpn"/>
 
     <CheckBox

--- a/app/src/main/res/layout/item_app_group.xml
+++ b/app/src/main/res/layout/item_app_group.xml
@@ -20,25 +20,36 @@
 
     <TextView
         android:id="@+id/group_title"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
         android:textColor="@color/gray50"
         android:textAppearance="@style/TextAppearance.Guardian.Header20"
+        android:textSize="15dp"
+        android:singleLine="true"
+        android:ellipsize="end"
         app:layout_constraintTop_toTopOf="@id/dropdown_arrow"
         app:layout_constraintBottom_toBottomOf="@id/dropdown_arrow"
         app:layout_constraintStart_toEndOf="@id/dropdown_arrow"
-        tools:text="Unprotected"/>
+        app:layout_constraintEnd_toStartOf="@id/group_action"
+        tools:text="Unprotected"
+        tools:ignore="SpUsage"/>
 
     <TextView
         android:id="@+id/group_description"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:textColor="@color/gray40"
         android:textAppearance="@style/TextAppearance.Guardian.Byline10"
+        android:textSize="13dp"
+        android:singleLine="true"
+        android:ellipsize="end"
         app:layout_constraintTop_toBottomOf="@id/group_title"
         app:layout_constraintStart_toStartOf="@id/group_title"
-        tools:text="These apps will not use the VPN"/>
+        app:layout_constraintEnd_toEndOf="@id/group_title"
+        tools:text="These apps will not use the VPN"
+        tools:ignore="SpUsage"/>
 
     <TextView
         android:id="@+id/group_action"
@@ -46,11 +57,13 @@
         android:layout_height="0dp"
         android:textColor="@color/blue50"
         android:textAppearance="@style/TextAppearance.Guardian.Body10"
+        android:textSize="15dp"
         android:foreground="?attr/selectableItemBackground"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="@id/group_description"
         app:layout_constraintEnd_toEndOf="parent"
-        tools:text="Protect all"/>
+        tools:text="Protect all"
+        tools:ignore="SpUsage"/>
 
     <include
         layout="@layout/view_information"

--- a/app/src/main/res/values/strings_nontranslatable.xml
+++ b/app/src/main/res/values/strings_nontranslatable.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <string name="label_vpn" translatable="false">VPN</string>
-    <string name="launcher_name" translatable="false">Firefox VPN</string>
+    <string name="launcher_name" translatable="false">Mozilla VPN</string>
     <string name="vpn_state_separator" translatable="false">&#8226;</string>
 
     <string name="log_report_subject" translatable="false">User Help Request: %1$s/%2$s</string>


### PR DESCRIPTION
- Toggle card corner radius should be 8px.
- Add missing header divider line.
- Truncate App Names 16px from right checkbox, ex. Google Play St…
- If VPN is on, the list is deactivated, still allow users to interact with accordions.
- Modify launcher name
- Prevent huge system font size effect