### PR TITLE
Ignore ktlint rule: import in lexicographic order

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{kt,kts}]
+disabled_rules = import-ordering
+


### PR DESCRIPTION
Android Studio doesn't have this feature. It's also not in the official [style-guide](https://developer.android.com/kotlin/style-guide#import_statements).