### PR TITLE
[AppTunneling] Use MATCH_ALL instead of MATCH_DEFAULT_ONLY when resolving browsable apps

### DIFF
--- a/app/src/main/java/org/mozilla/firefox/vpn/apptunneling/data/AppTunnelingRepository.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/apptunneling/data/AppTunnelingRepository.kt
@@ -72,7 +72,7 @@ class AppTunnelingRepository(
     private fun resolveBrowserApps(): List<ApplicationInfo> {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.mozilla.org/"))
             .apply { addCategory(Intent.CATEGORY_BROWSABLE) }
-        return packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+        return packageManager.queryIntentActivities(intent, PackageManager.MATCH_ALL)
             .map { it.activityInfo.applicationInfo }
     }
 }

--- a/app/src/main/java/org/mozilla/firefox/vpn/apptunneling/data/AppTunnelingRepository.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/apptunneling/data/AppTunnelingRepository.kt
@@ -72,6 +72,9 @@ class AppTunnelingRepository(
     private fun resolveBrowserApps(): List<ApplicationInfo> {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.mozilla.org/"))
             .apply { addCategory(Intent.CATEGORY_BROWSABLE) }
+        // We've tried using PackageManager.MATCH_DEFAULT_ONLY flag and found that browsers that
+        // are not set as the default browser won't be matched even if they had CATEGORY_DEFAULT set
+        // in the intent filter
         return packageManager.queryIntentActivities(intent, PackageManager.MATCH_ALL)
             .map { it.activityInfo.applicationInfo }
     }


### PR DESCRIPTION
After testing, even a component's intent filter is marked as browsable and default category. It still can't be resolved if it is not set as the default browser. So we decide to use MATCH_ALL instead.