### PR TITLE
Closes #254: Support for Always-On mode on API24+, auto-start on API23

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name="org.mozilla.firefox.vpn.GuardianApp"
@@ -82,6 +83,13 @@
                 android:resource="@xml/file_paths" />
 
         </provider>
+
+        <!-- Enables VPN auto-start on API23 devices -->
+        <receiver android:name="org.mozilla.firefox.vpn.receivers.LegacyBootBroadcastReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/org/mozilla/firefox/vpn/ext/Vpn.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/ext/Vpn.kt
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.firefox.vpn.ext
+
+import android.content.Context
+import android.util.Log
+import org.mozilla.firefox.vpn.apptunneling.domain.GetAppTunnelingSwitchStateUseCase
+import org.mozilla.firefox.vpn.apptunneling.domain.GetExcludeAppUseCase
+import org.mozilla.firefox.vpn.device.domain.CurrentDeviceUseCase
+import org.mozilla.firefox.vpn.guardianComponent
+import org.mozilla.firefox.vpn.main.vpn.ConnectionConfig
+import org.mozilla.firefox.vpn.servers.domain.FilterStrategy
+import org.mozilla.firefox.vpn.servers.domain.GetSelectedServerUseCase
+import org.mozilla.firefox.vpn.servers.domain.GetServersUseCase
+import org.mozilla.firefox.vpn.util.Result
+
+suspend fun Context.connectVpnIfPossible(logTag: String) {
+    Log.d(logTag, "connectVpnIfPossible...")
+
+    val vpnManager = this.guardianComponent.vpnManager
+    if (!vpnManager.isGranted()) {
+        Log.d(logTag, "Not granted")
+        return
+    }
+
+    if (vpnManager.isConnected()) {
+        Log.d(logTag, "Already connected")
+        return
+    }
+
+    val serverRepository = this.guardianComponent.serverRepo
+    val currentDevice = CurrentDeviceUseCase(
+        this.guardianComponent.deviceRepo,
+        this.guardianComponent.userRepo,
+        this.guardianComponent.userStateResolver
+    )()
+
+    if (currentDevice == null) {
+        Log.d(logTag, "No current device")
+        return
+    }
+
+    val selectedServerInfoResult = when (
+        val servers = GetServersUseCase(serverRepository).invoke(FilterStrategy.ByCity)
+    ) {
+        is Result.Success -> {
+            GetSelectedServerUseCase(serverRepository).invoke(FilterStrategy.ByCity, servers.value)
+        }
+        is Result.Fail -> {
+            Log.d(logTag, "Couldn't get servers")
+            return
+        }
+    }
+
+    val selectedServer = when (selectedServerInfoResult) {
+        is Result.Success -> selectedServerInfoResult.value
+        is Result.Fail -> {
+            Log.d(logTag, "Couldn't get selected server")
+            return
+        }
+    }
+
+    val getAppTunnelingSwitchStateUseCase = GetAppTunnelingSwitchStateUseCase(this.guardianComponent.appTunnelingRepo)
+    val getExcludeAppUseCase = GetExcludeAppUseCase(this.guardianComponent.appTunnelingRepo)
+    val excludeApps = if (getAppTunnelingSwitchStateUseCase()) {
+        getExcludeAppUseCase().toList()
+    } else {
+        emptyList()
+    }
+
+    Log.d(logTag, "vpnManager.connect...")
+    vpnManager.connect(selectedServer, ConnectionConfig(currentDevice, excludeApps = excludeApps))
+}

--- a/app/src/main/java/org/mozilla/firefox/vpn/main/vpn/GuardianVpnService.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/main/vpn/GuardianVpnService.kt
@@ -2,12 +2,18 @@ package org.mozilla.firefox.vpn.main.vpn
 
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import com.wireguard.android.backend.TunnelManager
 import com.wireguard.android.backend.WireGuardVpnService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.mozilla.firefox.vpn.GuardianApp
+import org.mozilla.firefox.vpn.ext.connectVpnIfPossible
 import org.mozilla.firefox.vpn.util.NotificationUtil
 
 class GuardianVpnService : WireGuardVpnService() {
+    private val logTag = "GuardianVpnService"
 
     private val component by lazy {
         (applicationContext as GuardianApp).guardianComponent
@@ -18,9 +24,30 @@ class GuardianVpnService : WireGuardVpnService() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val turnOn = {
+            startForeground(NotificationUtil.DEFAULT_NOTIFICATION_ID, NotificationUtil.createBaseBuilder(this).build())
+        }
         when (intent?.getStringExtra(EXTRA_COMMAND)) {
-            COMMAND_TURN_ON -> startForeground(NotificationUtil.DEFAULT_NOTIFICATION_ID, NotificationUtil.createBaseBuilder(this).build())
-            COMMAND_TURN_OFF -> stopForeground(false)
+            COMMAND_TURN_OFF -> {
+                Log.d(logTag, "Handling 'turn off' command")
+                // Service being turned off manually by the user.
+                stopForeground(false)
+            }
+            COMMAND_TURN_ON -> {
+                Log.d(logTag, "Handling 'turn on' command")
+                // Service being started manually by the user.
+                turnOn()
+            }
+            null -> {
+                Log.d(logTag, "Handling system startup")
+                // If Always-On mode is turned on, OS will start us without any extra flags.
+                // Below we'll "properly" start ourselves, setting up a tunnel with a selected server, etc.
+                // We'll end-up circling back to this method, since while it's turning on, wireguard's
+                // TunnelManager ends up starting this service with a COMMAND_TURN_ON extra.
+                CoroutineScope(Dispatchers.IO).launch {
+                    this@GuardianVpnService.connectVpnIfPossible(logTag)
+                }
+            }
         }
         return super.onStartCommand(intent, flags, startId)
     }

--- a/app/src/main/java/org/mozilla/firefox/vpn/receivers/Boot.kt
+++ b/app/src/main/java/org/mozilla/firefox/vpn/receivers/Boot.kt
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.firefox.vpn.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.mozilla.firefox.vpn.ext.connectVpnIfPossible
+
+/**
+ * Boot broadcast receiver for auto-starting VPN service on pre-N devices.
+ * This receiver is disabled for N+ devices. On these, Always-On VPN mode exists at the system-level,
+ * and is the system-approved way of doing this.
+ * In fact, newer Androids won't even allow us to do background work (such as starting a service) on boot.
+ */
+class LegacyBootBroadcastReceiver : BroadcastReceiver() {
+    private val logTag: String = "LegacyBootBroadcastReceiver"
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        Log.d(logTag, "onReceive")
+        // Only run on pre-24.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            Log.d(logTag, "Receiver disabled.")
+            return
+        }
+        if (context == null) {
+            Log.d(logTag, "No context, can't proceed.")
+            return
+        }
+        // 'boot' intents are protected (i.e. only OS is allowed to emit them), but it's still a
+        // good idea to make sure everything's in order.
+        if (intent == null || intent.action != Intent.ACTION_BOOT_COMPLETED) {
+            Log.w(logTag, "Intent not allowed.")
+            return
+        }
+        CoroutineScope(Dispatchers.IO).launch {
+            tryToConnect(context)
+        }
+    }
+
+    private suspend fun tryToConnect(context: Context) = context.connectVpnIfPossible(logTag)
+}


### PR DESCRIPTION
## Part 1:
Starting with API24, Android supports an Always-On vpn mode. This can be turned-on by the user,
and in response OS will startup configured VPN service on device boot, and after app upgrades.
Essentially, Android will attempt to always keep the VPN service around.

This patch introduces basic support for this mode. Our service startup changes a little bit.
When it's the OS that's starting us (either during boot, app upgrade, or when user turns-on Always-on mode
in system settings), it will start us without any extras in the intent. When we detect this, kick-off
a full startup as it would happen if the user switched-on VPN from within the UI itself.

This does introduce a bit of duplication of functionality - but it's mainly around how "use cases" are
wired together. Reducing this duplication would ideally require a refactor of how we manage use cases,
and that's not something I want to do right now. Besides, this duplication is pretty trivial.

"Normal" service startup (i.e. initialized from within the app itself) is unchanged.

## Part 2:
On API23 there's no Always-On VPN mode, so we do things a bit differently.
Instead of relying on the OS to start our vpn service, we do it ourselves
while handling the BOOT_COMPLETED intent.

This isn't something that's really feasible to do on newer devices (what can happen
in background services is pretty tightly restricted), but this approach works well
on older devices.

Actual "startup flow" is entirely shared with the Always-On startup logic.

End-result is that we launch the VPN service as it was last-configured by the user
shortly after booting.