### PR TITLE
Bump version to hardcoded 2.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,15 +17,9 @@ android {
         applicationId "org.mozilla.firefox.vpn"
         minSdkVersion 23
         targetSdkVersion 29
-        versionCode 1
-        versionName "1.2.1"
+        versionCode 2022
+        versionName "2.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-        def circleci_build_number = System.getenv("CIRCLE_BUILD_NUM")
-        if (circleci_build_number?.trim()) {
-            versionCode circleci_build_number.toInteger()
-            versionName "$versionName($circleci_build_number)"
-        }
     }
 
     compileOptions {


### PR DESCRIPTION
Sorry, again. Now against release and we're trying "2.0.2" to use